### PR TITLE
update to fit.isoreg function.

### DIFF
--- a/article_platt_scaling.R
+++ b/article_platt_scaling.R
@@ -113,7 +113,7 @@ fit.isoreg <- function(iso, x0)
 {
   o = iso$o
   if (is.null(o)) 
-    o = 1:length(x)
+    o = 1:length(iso$x)
   x = iso$x[o]
   y = iso$yf
   ind = cut(x0, breaks = x, labels = FALSE, include.lowest = TRUE)


### PR DESCRIPTION
variable 'o' in the function needs to be assigned properly. Otherwise, the function will throw an error as below:

Error in cut.default(x0, breaks = x, labels = FALSE, include.lowest = TRUE) : 
  invalid number of intervals